### PR TITLE
Disambiguate MongoDB -> MongoDB (inc) Atlas service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # MongoStore
-MongoStore is an open-source alternative to Roblox's DataStoreService
+MongoStore is an open-source alternative to Roblox's DataStoreService, leveraging the MongoDB Atlas platform.

--- a/src/MongoStore.lua
+++ b/src/MongoStore.lua
@@ -2,13 +2,13 @@
 
 	MongoStore is an alternative to DataStoreService
 	which uses the Rongo module as an interface to
-	MongoDB.
+	MongoDB Atlas.
 	
 	MongoStore includes quite a few of the functions
 	which DataStoreService has and it aims to make the
 	transition from DataStoreService as smooth as possible
 	
-	You will need a MongoDB account to use MongoStore
+	You will need a MongoDB Atlas account to use MongoStore
 	
 	Version: 1.0.0
 	License: MIT License


### PR DESCRIPTION
Similar to Starnamics/Rongo#2, Disambiguate MongoDB (colloquially the DB software) and Atlas, the company's cloud-host DB solution.